### PR TITLE
Fix/page change event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@teamhive/pdf-viewer",
-    "version": "4.0.0",
+    "version": "4.0.2",
     "description": "PDF Viewer Web Component. Built with stencil and pdfjs.",
     "homepage": "https://github.com/TeamHive/pdf-viewer",
     "repository": {

--- a/src/components/pdf-viewer/pdf-viewer.tsx
+++ b/src/components/pdf-viewer/pdf-viewer.tsx
@@ -175,7 +175,7 @@ export class PdfViewer {
     }
 
     handlePageChange(e: any) {
-        this.pageChange.emit(e.pageNumber);
+        this.pageChange.emit(e.detail.pageNumber);
     }
 
     handleLinkClick(e: any) {

--- a/src/components/pdf-viewer/pdf-viewer.tsx
+++ b/src/components/pdf-viewer/pdf-viewer.tsx
@@ -159,8 +159,9 @@ export class PdfViewer {
     }
 
     addEventListeners() {
-        this.viewerContainer = this.iframeEl.contentDocument.body.querySelector('#viewerContainer')
-        this.viewerContainer.addEventListener('pagechange', this.handlePageChange.bind(this));
+        this.viewerContainer = this.iframeEl.contentDocument.body.querySelector('#viewerContainer');
+
+        this.iframeEl.contentDocument.addEventListener('pagechanging', this.handlePageChange.bind(this));
         this.viewerContainer.addEventListener('click', this.handleLinkClick.bind(this));
 
         this.updateScrolling();


### PR DESCRIPTION
Fixes listening to bubbled DOM events through the event bus in pdf.js. Updates the app options to allow the events to pass through the event bus to the DOM. 

This impacts all events we were listening to, but most visible to our implementation was the page change wasn't firing anymore. 